### PR TITLE
Make FastAPI versions flexible from 0.109.0 to 0.110.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.8"
-fastapi = ">=0.110.0"
+fastapi = ">=0.109.0,<0.110.0"
 PyJWT = ">=2.8.0"
 httpx = ">=0.23.3"
 pydantic-settings = ">=2.2.1"


### PR DESCRIPTION
This is a PR for this issue: https://github.com/sijokun/async-fastapi-jwt-auth/issues/17#issue-2257319328